### PR TITLE
Refactor to NRS controller and HTTP parser and added missing NRS controller ITs

### DIFF
--- a/app/connectors/NrsConnector.scala
+++ b/app/connectors/NrsConnector.scala
@@ -19,12 +19,9 @@ package connectors
 import config.MicroserviceAppConfig
 import connectors.httpParsers.NrsResponseParsers._
 import javax.inject.Inject
-import models.Error
 import models.nrs.{AppJson, NrsReceiptRequestModel}
-import play.api.Logger
-import uk.gov.hmrc.http.{GatewayTimeoutException, HeaderCarrier}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
-import play.api.http.Status.GATEWAY_TIMEOUT
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -40,10 +37,5 @@ class NrsConnector @Inject()(http: HttpClient, appConfig: MicroserviceAppConfig)
         "X-API-Key" -> appConfig.nrsApiKey
       )
     )
-  }.recover {
-    case _: GatewayTimeoutException => Left(Error(GATEWAY_TIMEOUT.toString, "Request to NRS timed out."))
-    case error: Throwable =>
-      Logger.warn("[NrsConnector][nrsReceiptSubmission] Unexpected exception returned from NRS", error)
-      Left(Error("UNEXPECTED_EXCEPTION", error.getMessage))
   }
 }

--- a/app/connectors/httpParsers/NrsResponseParsers.scala
+++ b/app/connectors/httpParsers/NrsResponseParsers.scala
@@ -30,14 +30,18 @@ object NrsResponseParsers extends ResponseHttpParsers {
   private implicit def intToString: Int => String = _.toString
 
   def handleErrorCodes(input: HttpResponse): Left[Error, Nothing] = {
-    Logger.warn(s"[NrsResponseParsers][handleErrorCodes] Error returned from NRS: ${input.status}. Return body: ${input.body}")
+    Logger.debug(s"[NrsResponseParsers][handleErrorCodes] NRS returned ${input.status}. Body: ${input.body}")
+    Logger.warn(s"[NrsResponseParsers][handleErrorCodes] NRS returned ${input.status}.")
+
     input.status match {
-      case BAD_REQUEST => Left(Error(BAD_REQUEST, "Request parameters are invalid"))
-      case UNAUTHORIZED => Left(Error(UNAUTHORIZED, "X-API-Key is either invalid, or missing."))
-      case CHECKSUM_FAILED => Left(Error(CHECKSUM_FAILED, "The provided Sha256Checksum provided does not match the decoded payload Sha256Checksum."))
-      case unknown500ErrorOr404 if unknown500ErrorOr404 == NOT_FOUND || (unknown500ErrorOr404 >= 500 && unknown500ErrorOr404 < 600) =>
-        Left(Error(unknown500ErrorOr404, "Returning response body:\n" + input.json))
-      case unknownReturnCode => Left(Error(unknownReturnCode, "Unexpected return code, returning response body:\n" + input.json))
+      case BAD_REQUEST =>
+        Left(Error(BAD_REQUEST, "Request parameters are invalid"))
+      case UNAUTHORIZED =>
+        Left(Error(UNAUTHORIZED, "X-API-Key is either invalid, or missing."))
+      case CHECKSUM_FAILED =>
+        Left(Error(CHECKSUM_FAILED, "The provided Sha256Checksum provided does not match the decoded payload Sha256Checksum."))
+      case status =>
+        Left(Error(status, input.body))
     }
   }
 

--- a/app/connectors/httpParsers/NrsResponseParsers.scala
+++ b/app/connectors/httpParsers/NrsResponseParsers.scala
@@ -20,6 +20,7 @@ import models.Error
 import models.nrs.NrsReceiptSuccessModel
 import play.api.Logger
 import play.api.http.Status._
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 
 object NrsResponseParsers extends ResponseHttpParsers {
@@ -41,7 +42,7 @@ object NrsResponseParsers extends ResponseHttpParsers {
       case CHECKSUM_FAILED =>
         Left(Error(CHECKSUM_FAILED, "The provided Sha256Checksum provided does not match the decoded payload Sha256Checksum."))
       case status =>
-        Left(Error(status, input.body))
+        Left(Error(status, Json.stringify(input.json)))
     }
   }
 

--- a/app/controllers/NRSController.scala
+++ b/app/controllers/NRSController.scala
@@ -22,7 +22,7 @@ import models.Error
 import models.nrs.NrsReceiptRequestModel
 import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, Json}
-import play.api.mvc.{Action, AnyContent, Result}
+import play.api.mvc.{Action, AnyContent}
 import services.NrsSubmissionService
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
@@ -49,14 +49,14 @@ class NRSController @Inject()(authorisedAction: AuthorisedSubmitVatReturn,
                 Status(error.code.toInt)(Json.toJson(error.reason))
             }
           case JsError(error) =>
-            Logger.debug(s"[NRSController][submitNRS] - request body from submit-vat-return-frontend does not pass validation: $error")
-            Logger.warn(s"[NRSController][submitNRS] - request body from submit-vat-return-frontend does not pass validation")
-            Future.successful(BadRequest(Json.toJson(Error("400", "Request body from submit-vat-return-frontend does not pass validation"))))
+            Logger.debug(s"[NRSController][submitNRS] - request body does not pass validation: $error")
+            Logger.warn(s"[NRSController][submitNRS] - request body does not pass validation")
+            Future.successful(BadRequest(Json.toJson(Error("400", "Request body does not pass validation"))))
         }
       case None =>
         Logger.debug(s"[NRSController][submitNRS] - request body cannot be parsed to JSON. Body: ${request.body}")
         Logger.warn("[NRSController][submitNRS] - request body cannot be parsed to JSON")
-        Future.successful(BadRequest(Json.toJson(Error("400", "Request body from submit-vat-return-frontend cannot be parsed to JSON."))))
+        Future.successful(BadRequest(Json.toJson(Error("400", "Request body cannot be parsed to JSON."))))
     }
   }
 }

--- a/it/connectors/NrsConnectorISpec.scala
+++ b/it/connectors/NrsConnectorISpec.scala
@@ -82,9 +82,12 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "all values are valid" in {
         val successResponse: NrsReceiptSuccessModel = NrsReceiptSuccessModel("submission successful")
 
-        stubSubmissionResponse(ACCEPTED, Right(successResponse), "not-a-key")
+        stubSubmissionResponse(ACCEPTED, Right(successResponse), vrn = None)
 
-        val result = await(connector.nrsReceiptSubmission(requestModel))
+        val result = {
+          mockAppConfig.features.useStubFeature(false)
+          await(connector.nrsReceiptSubmission(requestModel))
+        }
 
         result shouldBe Right(successResponse)
       }
@@ -95,9 +98,12 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the request parameters are invalid (BAD_REQUEST)" in {
         val expectedResponse = Error(BAD_REQUEST, "Request parameters are invalid")
 
-        stubSubmissionResponse(BAD_REQUEST, Left(Error(BAD_REQUEST, "This model doesn't really matter here")), "not-a-key")
+        stubSubmissionResponse(BAD_REQUEST, Left(Error(BAD_REQUEST, "This model doesn't really matter here")), vrn = None)
 
-        val result = await(connector.nrsReceiptSubmission(requestModel))
+        val result = {
+          mockAppConfig.features.useStubFeature(false)
+          await(connector.nrsReceiptSubmission(requestModel))
+        }
 
         result shouldBe Left(expectedResponse)
       }
@@ -105,9 +111,12 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the API key is wrong (UNAUTHORIZED)" in {
         val expectedResponse = Error(UNAUTHORIZED, "X-API-Key is either invalid, or missing.")
 
-        stubSubmissionResponse(UNAUTHORIZED, Left(Error(UNAUTHORIZED, "This model doesn't really matter here")), "not-a-key")
+        stubSubmissionResponse(UNAUTHORIZED, Left(Error(UNAUTHORIZED, "This model doesn't really matter here")), vrn = None)
 
-        val result = await(connector.nrsReceiptSubmission(requestModel))
+        val result = {
+          mockAppConfig.features.useStubFeature(false)
+          await(connector.nrsReceiptSubmission(requestModel))
+        }
 
         result shouldBe Left(expectedResponse)
       }
@@ -115,9 +124,12 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the checksum fails (Custom 419)" in {
         val expectedResponse = Error(CHECKSUM_FAILED, "The provided Sha256Checksum provided does not match the decoded payload Sha256Checksum.")
 
-        stubSubmissionResponse(CHECKSUM_FAILED, Left(Error(CHECKSUM_FAILED, "This model doesn't really matter here")), "not-a-key")
+        stubSubmissionResponse(CHECKSUM_FAILED, Left(Error(CHECKSUM_FAILED, "This model doesn't really matter here")), vrn = None)
 
-        val result = await(connector.nrsReceiptSubmission(requestModel))
+        val result = {
+          mockAppConfig.features.useStubFeature(false)
+          await(connector.nrsReceiptSubmission(requestModel))
+        }
 
         result shouldBe Left(expectedResponse)
       }
@@ -125,9 +137,12 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "any other code is received" in {
         val expectedResponse = Error(INTERNAL_SERVER_ERROR, Json.toJson(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")).toString())
 
-        stubSubmissionResponse(INTERNAL_SERVER_ERROR, Left(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")), "not-a-key")
+        stubSubmissionResponse(INTERNAL_SERVER_ERROR, Left(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")), vrn = None)
 
-        val result = await(connector.nrsReceiptSubmission(requestModel))
+        val result = {
+          mockAppConfig.features.useStubFeature(false)
+          await(connector.nrsReceiptSubmission(requestModel))
+        }
 
         result shouldBe Left(expectedResponse)
       }
@@ -141,7 +156,7 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "all values are valid" in {
         val successResponse: NrsReceiptSuccessModel = NrsReceiptSuccessModel("submission successful")
 
-        stubSubmissionResponse(ACCEPTED, Right(successResponse), "not-a-key")
+        stubSubmissionResponse(ACCEPTED, Right(successResponse))
 
         val result = await(connector.nrsReceiptSubmission(requestModel))
 
@@ -154,7 +169,7 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the request parameters are invalid (BAD_REQUEST)" in {
         val expectedResponse = Error(BAD_REQUEST, "Request parameters are invalid")
 
-        stubSubmissionResponse(BAD_REQUEST, Left(Error(BAD_REQUEST, "Bad Request")), "not-a-key")
+        stubSubmissionResponse(BAD_REQUEST, Left(Error(BAD_REQUEST, "Bad Request")))
 
         val result = await(connector.nrsReceiptSubmission(requestModel))
 
@@ -164,7 +179,7 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the API key is wrong (UNAUTHORIZED)" in {
         val expectedResponse = Error(UNAUTHORIZED, "X-API-Key is either invalid, or missing.")
 
-        stubSubmissionResponse(UNAUTHORIZED, Left(Error(UNAUTHORIZED, "Unauthorized")), "not-a-key")
+        stubSubmissionResponse(UNAUTHORIZED, Left(Error(UNAUTHORIZED, "Unauthorized")))
 
         val result = await(connector.nrsReceiptSubmission(requestModel))
 
@@ -174,7 +189,7 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the checksum fails (Custom 419)" in {
         val expectedResponse = Error(CHECKSUM_FAILED, "The provided Sha256Checksum provided does not match the decoded payload Sha256Checksum.")
 
-        stubSubmissionResponse(CHECKSUM_FAILED, Left(Error(CHECKSUM_FAILED, "Checksum failure")), "not-a-key")
+        stubSubmissionResponse(CHECKSUM_FAILED, Left(Error(CHECKSUM_FAILED, "Checksum failure")))
 
         val result = await(connector.nrsReceiptSubmission(requestModel))
 
@@ -184,7 +199,7 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "any other code is received" in {
         val expectedResponse = Error(INTERNAL_SERVER_ERROR, Json.toJson(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")).toString())
 
-        stubSubmissionResponse(INTERNAL_SERVER_ERROR, Left(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")), "not-a-key")
+        stubSubmissionResponse(INTERNAL_SERVER_ERROR, Left(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")))
 
         val result = await(connector.nrsReceiptSubmission(requestModel))
 

--- a/it/connectors/NrsConnectorISpec.scala
+++ b/it/connectors/NrsConnectorISpec.scala
@@ -18,27 +18,16 @@ package connectors
 
 import java.time.LocalDateTime
 
-import config.MicroserviceAppConfig
+import helpers.ComponentSpecBase
 import helpers.servicemocks.NrsStub._
-import helpers.{ComponentSpecBase, WireMockHelper}
-import javax.inject.Inject
 import models.Error
 import models.nrs._
 import models.nrs.identityData._
 import play.api.http.Status._
 import play.api.libs.json.Json
-import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
-
-class MockAppConfig @Inject()(override val environment: Environment, implicit val configuration: Configuration)
-  extends MicroserviceAppConfig(environment, configuration) {
-
-  import WireMockHelper._
-
-  override val nrsSubmissionEndpoint: String = s"$url/submission"
-}
 
 class NrsConnectorISpec extends ComponentSpecBase {
   implicit def intToString: Int => String = _.toString
@@ -83,154 +72,91 @@ class NrsConnectorISpec extends ComponentSpecBase {
 
   private val CHECKSUM_FAILED = 419
 
-  val mockConfig: MockAppConfig = app.injector.instanceOf[MockAppConfig]
   val httpClient: HttpClient = app.injector.instanceOf[HttpClient]
-  val connector: NrsConnector = new NrsConnector(httpClient, mockConfig)
+  val connector: NrsConnector = new NrsConnector(httpClient, mockAppConfig)
 
   "nrsReceiptSubmission is called and the feature switch is off" should {
+    
     "return success" when {
+      
       "all values are valid" in {
         val successResponse: NrsReceiptSuccessModel = NrsReceiptSuccessModel("submission successful")
 
         stubSubmissionResponse(ACCEPTED, Right(successResponse), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Right(successResponse)
       }
     }
 
     "return an error" when {
+
       "the request parameters are invalid (BAD_REQUEST)" in {
         val expectedResponse = Error(BAD_REQUEST, "Request parameters are invalid")
 
         stubSubmissionResponse(BAD_REQUEST, Left(Error(BAD_REQUEST, "This model doesn't really matter here")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
       }
+
       "the API key is wrong (UNAUTHORIZED)" in {
         val expectedResponse = Error(UNAUTHORIZED, "X-API-Key is either invalid, or missing.")
 
         stubSubmissionResponse(UNAUTHORIZED, Left(Error(UNAUTHORIZED, "This model doesn't really matter here")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
       }
-      "NRS is not available (NOT_FOUND)" in {
-        val expectedResponse = Error(NOT_FOUND, s"Returning response body:\n${Json.toJson(Error(NOT_FOUND, "This model doesn't really matter here"))}")
 
-        stubSubmissionResponse(NOT_FOUND, Left(Error(NOT_FOUND, "This model doesn't really matter here")), "not-a-key")
-
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
-
-        result shouldBe Left(expectedResponse)
-      }
       "the checksum fails (Custom 419)" in {
         val expectedResponse = Error(CHECKSUM_FAILED, "The provided Sha256Checksum provided does not match the decoded payload Sha256Checksum.")
 
         stubSubmissionResponse(CHECKSUM_FAILED, Left(Error(CHECKSUM_FAILED, "This model doesn't really matter here")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
       }
-      "a 5xx is received" in {
-        val expectedResponse = Error(INTERNAL_SERVER_ERROR, s"Returning response body:\n${
-          Json.toJson(Error(CHECKSUM_FAILED,
-            "This model doesn't really matter here"))
-        }")
 
-        stubSubmissionResponse(INTERNAL_SERVER_ERROR, Left(Error(CHECKSUM_FAILED, "This model doesn't really matter here")), "not-a-key")
-
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
-
-        result shouldBe Left(expectedResponse)
-      }
       "any other code is received" in {
-        val expectedResponse = Error(GONE, s"Unexpected return code, returning response body:\n${
-          Json.toJson(Error(SEE_OTHER,
-            "Where did they come from, where did they go?"))
-        }")
+        val expectedResponse = Error(INTERNAL_SERVER_ERROR, Json.toJson(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")).toString())
 
-        stubSubmissionResponse(GONE, Left(Error(SEE_OTHER, "Where did they come from, where did they go?")), "not-a-key")
+        stubSubmissionResponse(INTERNAL_SERVER_ERROR, Left(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
-      }
-      "there is a timeout" in {
-        stubTimeoutResponse()
-
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
-
-        result shouldBe Left(Error(GATEWAY_TIMEOUT, "Request to NRS timed out."))
-      }
-      "there is an unexpected exception" in {
-        stubExceptionResponse()
-
-        val result = {
-          mockConfig.features.useStubFeature(false)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
-
-        result shouldBe Left(Error("UNEXPECTED_EXCEPTION", "Remotely closed"))
       }
     }
   }
 
   "nrsReceiptSubmission is called and the feature switch is on" should {
+
     "return success" when {
+
       "all values are valid" in {
         val successResponse: NrsReceiptSuccessModel = NrsReceiptSuccessModel("submission successful")
 
-        stubSubmissionResponse(ACCEPTED, Right(successResponse), "not-a-key", vrn = Some("123456789"))
+        stubSubmissionResponse(ACCEPTED, Right(successResponse), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(true)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Right(successResponse)
       }
     }
 
     "return an error" when {
+
       "the request parameters are invalid (BAD_REQUEST)" in {
         val expectedResponse = Error(BAD_REQUEST, "Request parameters are invalid")
 
-        stubSubmissionResponse(BAD_REQUEST, Left(Error(BAD_REQUEST, "Bad Request")), "not-a-key", vrn = Some("123456789"))
+        stubSubmissionResponse(BAD_REQUEST, Left(Error(BAD_REQUEST, "Bad Request")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(true)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
       }
@@ -238,25 +164,9 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the API key is wrong (UNAUTHORIZED)" in {
         val expectedResponse = Error(UNAUTHORIZED, "X-API-Key is either invalid, or missing.")
 
-        stubSubmissionResponse(UNAUTHORIZED, Left(Error(UNAUTHORIZED, "Unauthorized")), "not-a-key", vrn = Some("123456789"))
+        stubSubmissionResponse(UNAUTHORIZED, Left(Error(UNAUTHORIZED, "Unauthorized")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(true)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
-
-        result shouldBe Left(expectedResponse)
-      }
-
-      "NRS is not available (NOT_FOUND)" in {
-        val expectedResponse = Error(NOT_FOUND, s"Returning response body:\n${Json.toJson(Error(NOT_FOUND, "Not Found"))}")
-
-        stubSubmissionResponse(NOT_FOUND, Left(Error(NOT_FOUND, "Not Found")), "not-a-key", vrn = Some("123456789"))
-
-        val result = {
-          mockConfig.features.useStubFeature(true)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
       }
@@ -264,45 +174,19 @@ class NrsConnectorISpec extends ComponentSpecBase {
       "the checksum fails (Custom 419)" in {
         val expectedResponse = Error(CHECKSUM_FAILED, "The provided Sha256Checksum provided does not match the decoded payload Sha256Checksum.")
 
-        stubSubmissionResponse(CHECKSUM_FAILED, Left(Error(CHECKSUM_FAILED, "Checksum failure")), "not-a-key", vrn = Some("123456789"))
+        stubSubmissionResponse(CHECKSUM_FAILED, Left(Error(CHECKSUM_FAILED, "Checksum failure")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(true)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
-
-        result shouldBe Left(expectedResponse)
-      }
-
-      "a 5xx is received" in {
-        val expectedResponse = Error(INTERNAL_SERVER_ERROR, s"Returning response body:\n${
-          Json.toJson(Error(CHECKSUM_FAILED,
-            "Checksum failure"))
-        }")
-
-        stubSubmissionResponse(INTERNAL_SERVER_ERROR,
-          Left(Error(CHECKSUM_FAILED, "Checksum failure")), "not-a-key", vrn = Some("123456789"))
-
-        val result = {
-          mockConfig.features.useStubFeature(true)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
       }
 
       "any other code is received" in {
-        val expectedResponse = Error(GONE, s"Unexpected return code, returning response body:\n${
-          Json.toJson(Error(SEE_OTHER,
-            "Redirection Error"))
-        }")
+        val expectedResponse = Error(INTERNAL_SERVER_ERROR, Json.toJson(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")).toString())
 
-        stubSubmissionResponse(GONE, Left(Error(SEE_OTHER, "Redirection Error")), "not-a-key", vrn = Some("123456789"))
+        stubSubmissionResponse(INTERNAL_SERVER_ERROR, Left(Error(INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR")), "not-a-key")
 
-        val result = {
-          mockConfig.features.useStubFeature(true)
-          await(connector.nrsReceiptSubmission(requestModel))
-        }
+        val result = await(connector.nrsReceiptSubmission(requestModel))
 
         result shouldBe Left(expectedResponse)
       }

--- a/it/connectors/SubmitVatReturnConnectorSpec.scala
+++ b/it/connectors/SubmitVatReturnConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/controllers/NRSControllerISpec.scala
+++ b/it/controllers/NRSControllerISpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import helpers.ComponentSpecBase
+import helpers.servicemocks.{AuthStub, NrsStub}
+import models.nrs._
+import play.api.http.Status._
+import play.api.libs.json.Json
+
+class NRSControllerISpec extends ComponentSpecBase {
+
+  "Posting to /nrs/submission/:vrn" when {
+
+    "user is authorised" when {
+
+      "request body is valid" when {
+
+        val validJson = Json.obj(
+          "payload" -> "abcdefg",
+          "metadata" -> Json.obj(
+            "businessId" -> "anId",
+            "notableEvent" -> "anEvent",
+            "payloadContentType" -> "text/html",
+            "payloadSha256Checksum" -> "checksum",
+            "nrSubmissionId" -> "submission id",
+            "userSubmissionTimestamp" -> "2019-08-19T13:21:37.126Z",
+            "identityData" -> Json.obj(
+              "internalId" -> "int-id",
+              "externalId" -> "ext-id",
+              "agentCode" -> "agent code",
+              "credentials" -> Json.obj(
+                "providerId" -> "someId",
+                "providerType" -> "someType"
+              ),
+              "confidenceLevel" -> 200,
+              "nino" -> "fake nino",
+              "name" -> Json.obj(
+                "name" -> "First",
+                "lastName" -> "Last"
+              ),
+              "email" -> "user@test.com",
+              "agentInformation" -> Json.obj(
+                "agentCode" -> "Agent Code",
+                "agentFriendlyName" -> "Agent Name",
+                "agentId" -> "AGNT"
+              ),
+              "groupIdentifier" -> "group ID",
+              "credentialRole" -> "role",
+              "itmpName" -> Json.obj(
+                "givenName" -> "Given",
+                "middleName" -> "Middle",
+                "familyName" -> "Last"
+              ),
+              "itmpDateOfBirth" -> "1900-01-01",
+              "itmpAddress" -> Json.obj(
+                "line1" -> "Line 1",
+                "postCode" -> "LN11NE",
+                "countryName" -> "ENGLAND",
+                "countryCode" -> "EN"
+              ),
+              "loginTimes" -> Json.obj(
+                "currentLogin" -> "2019-08-19T13:21:37.126Z",
+                "previousLogin" -> "2019-08-19T13:21:37.126Z"
+              )
+            ),
+            "userAuthToken" -> "someToken",
+            "headerData" -> Json.obj(
+              "key" -> "value"
+            ),
+            "searchKeys" -> Json.obj(
+              "vrn" -> "123456789",
+              "periodKey" -> "18AA"
+            ),
+            "receiptData" -> Json.obj(
+              "language" -> "en",
+              "checkYourAnswersSections" -> Json.arr(
+                Json.obj(
+                  "title" -> "title",
+                  "data" -> Json.arr(
+                    Json.obj(
+                      "questionId" -> "questionId",
+                      "question" -> "question",
+                      "answer" ->"answer"
+                    )
+                  )
+                )
+              ),
+              "declaration" -> Json.obj(
+                "declarationText" -> "declaration",
+                "declarationName" -> "declarationName",
+                "declarationConsent" -> true
+              )
+            )
+          )
+        )
+
+        "NRS submission is successful" should {
+
+          "return ACCEPTED" in {
+
+            AuthStub.stubResponse()
+            NrsStub.stubSubmissionResponse(ACCEPTED, Right(NrsReceiptSuccessModel("12345")), "not-a-key")
+
+            val response = await(post("/nrs/submission/999999999")(validJson))
+
+            response.status shouldBe 202
+            response.json shouldBe Json.obj("nrSubmissionId" -> "12345")
+          }
+        }
+
+        "NRS submission is unsuccessful" should {
+
+          "return error status code" in {
+
+          }
+        }
+      }
+
+      "request body is invalid" should {
+
+        "return BAD_REQUEST" in {
+
+        }
+      }
+    }
+
+    "user is unauthorised" should {
+
+      "return UNAUTHORIZED" in {
+
+      }
+    }
+  }
+}

--- a/it/controllers/NRSControllerISpec.scala
+++ b/it/controllers/NRSControllerISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ class NRSControllerISpec extends ComponentSpecBase {
           "return ACCEPTED" in {
 
             AuthStub.stubResponse()
-            NrsStub.stubSubmissionResponse(ACCEPTED, Right(NrsReceiptSuccessModel("12345")), "not-a-key")
+            NrsStub.stubSubmissionResponse(ACCEPTED, Right(NrsReceiptSuccessModel("12345")))
 
             val response = await(post("/nrs/submission/999999999")(validJson))
 
@@ -130,7 +130,7 @@ class NRSControllerISpec extends ComponentSpecBase {
           "return the original error status code and body returned from NRS" in {
 
             AuthStub.stubResponse()
-            NrsStub.stubSubmissionResponse(SERVICE_UNAVAILABLE, Left(Error("503", "Error body")), "not-a-key")
+            NrsStub.stubSubmissionResponse(SERVICE_UNAVAILABLE, Left(Error("503", "Error body")))
 
             val response = await(post("/nrs/submission/999999999")(validJson))
 
@@ -152,7 +152,7 @@ class NRSControllerISpec extends ComponentSpecBase {
           val response = await(post("/nrs/submission/999999999")("just a string"))
 
           response.status shouldBe 400
-          response.json shouldBe Json.obj("code" -> "400", "reason" -> "Request body from submit-vat-return-frontend cannot be parsed to JSON.")
+          response.json shouldBe Json.obj("code" -> "400", "reason" -> "Request body cannot be parsed to JSON.")
         }
       }
 
@@ -165,7 +165,7 @@ class NRSControllerISpec extends ComponentSpecBase {
           val response = await(post("/nrs/submission/999999999")(Json.obj("not-valid" -> "not-valid")))
 
           response.status shouldBe 400
-          response.json shouldBe Json.obj("code" -> "400", "reason" -> "Request body from submit-vat-return-frontend does not pass validation")
+          response.json shouldBe Json.obj("code" -> "400", "reason" -> "Request body does not pass validation")
         }
       }
     }

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -23,7 +23,6 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.http.Writeable
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.JsValue
 import play.api.libs.ws.WSResponse
 import play.api.{Application, Environment, Mode}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -63,13 +62,17 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    mockAppConfig.features.useStubFeature(true)
     startWireMock()
   }
 
   override def afterAll(): Unit = {
     stopWireMock()
     super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    mockAppConfig.features.useStubFeature(true)
   }
 
   def post[T](path: String, headers: Map[String, String] = Map.empty)(body: T)(implicit wrt: Writeable[T]): WSResponse =

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -17,13 +17,12 @@
 package helpers
 
 import akka.stream.Materializer
-import binders.VatReturnsBinders
-import models.VatReturnFilters
+import config.MicroserviceAppConfig
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{JsValue, Writes}
+import play.api.libs.json.JsValue
 import play.api.libs.ws.WSResponse
 import play.api.{Application, Environment, Mode}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -42,6 +41,7 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
   implicit val mat: Materializer = app.injector.instanceOf[Materializer]
+  lazy val mockAppConfig: MicroserviceAppConfig = app.injector.instanceOf[MicroserviceAppConfig]
 
   def config: Map[String, String] = Map(
     "microservice.services.auth.host" -> mockHost,
@@ -50,7 +50,9 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
     "microservice.services.des.endpoints.vatReturnsUrlStart" -> mockEndpointStart,
     "microservice.services.des.endpoints.submitVatReturn" -> mockSubmitVatReturn,
     "microservice.services.des.environment" -> mockEnvironment,
-    "microservice.services.des.authorization-token" -> mockToken
+    "microservice.services.des.authorization-token" -> mockToken,
+    "microservice.services.nrs.receipts.host" -> s"http://$mockHost",
+    "microservice.services.nrs.receipts.port" -> mockPort
   )
 
   override implicit lazy val app: Application = new GuiceApplicationBuilder()
@@ -60,6 +62,7 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    mockAppConfig.features.useStubFeature(true)
     startWireMock()
   }
 

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -21,6 +21,7 @@ import config.MicroserviceAppConfig
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.http.Writeable
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.libs.ws.WSResponse
@@ -71,7 +72,7 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
     super.afterAll()
   }
 
-  def post(path: String, headers: Map[String, String] = Map.empty)(body: JsValue): WSResponse =
+  def post[T](path: String, headers: Map[String, String] = Map.empty)(body: T)(implicit wrt: Writeable[T]): WSResponse =
     await(buildClient(path, headers).post(body))
 
   def get(uri: String): WSResponse = {

--- a/it/helpers/servicemocks/NrsStub.scala
+++ b/it/helpers/servicemocks/NrsStub.scala
@@ -26,9 +26,11 @@ import play.api.http.Status.ACCEPTED
 import play.api.libs.json.Json
 
 object NrsStub extends WireMockMethods {
-  private def uri(vrn: Option[String]) = "/submission" + vrn.fold("")(vrnValue => s"/$vrnValue")
 
-  def stubSubmissionResponse(status: Int, response: Either[Error, NrsReceiptSuccessModel], apiKey: String, vrn: Option[String] = None): StubMapping = {
+  private val vrn = "123456789"
+  private def uri(vrn: String) = s"/submission/$vrn"
+
+  def stubSubmissionResponse(status: Int, response: Either[Error, NrsReceiptSuccessModel], apiKey: String, vrn: String = vrn): StubMapping = {
     when(POST, uri(vrn), Map(
       "Content-Type" -> AppJson,
       "X-API-Key" -> apiKey
@@ -37,7 +39,7 @@ object NrsStub extends WireMockMethods {
     )
   }
 
-  def stubTimeoutResponse(vrn: Option[String] = None): StubMapping = {
+  def stubTimeoutResponse(vrn: String = vrn): StubMapping = {
     stubFor(
       post(uri(vrn)).willReturn(
         aResponse()
@@ -48,7 +50,7 @@ object NrsStub extends WireMockMethods {
     )
   }
 
-  def stubExceptionResponse(vrn: Option[String] = None): StubMapping = {
+  def stubExceptionResponse(vrn: String = vrn): StubMapping = {
     stubFor(
       post(uri(vrn)).willReturn(
         aResponse()
@@ -56,5 +58,4 @@ object NrsStub extends WireMockMethods {
       )
     )
   }
-
 }

--- a/it/helpers/servicemocks/NrsStub.scala
+++ b/it/helpers/servicemocks/NrsStub.scala
@@ -16,46 +16,25 @@
 
 package helpers.servicemocks
 
-import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import helpers.WireMockMethods
 import models.Error
 import models.nrs.{AppJson, NrsReceiptSuccessModel}
-import play.api.http.Status.ACCEPTED
 import play.api.libs.json.Json
 
 object NrsStub extends WireMockMethods {
 
-  private val vrn = "123456789"
-  private def uri(vrn: String) = s"/submission/$vrn"
+  private val defaultVrn = "123456789"
+  private def uri(vrn: Option[String]) = "/submission" + vrn.fold("")(vrnValue => s"/$vrnValue")
 
-  def stubSubmissionResponse(status: Int, response: Either[Error, NrsReceiptSuccessModel], apiKey: String, vrn: String = vrn): StubMapping = {
+  def stubSubmissionResponse(status: Int,
+                             response: Either[Error, NrsReceiptSuccessModel],
+                             vrn: Option[String] = Some(defaultVrn)): StubMapping = {
     when(POST, uri(vrn), Map(
       "Content-Type" -> AppJson,
-      "X-API-Key" -> apiKey
+      "X-API-Key" -> "not-a-key"
     )).thenReturn(
       status = status, body = response.fold(Json.toJson(_), Json.toJson(_))
-    )
-  }
-
-  def stubTimeoutResponse(vrn: String = vrn): StubMapping = {
-    stubFor(
-      post(uri(vrn)).willReturn(
-        aResponse()
-          .withFixedDelay(2000)
-          .withBody(Json.toJson(NrsReceiptSuccessModel("some-return")).toString())
-          .withStatus(ACCEPTED)
-      )
-    )
-  }
-
-  def stubExceptionResponse(vrn: String = vrn): StubMapping = {
-    stubFor(
-      post(uri(vrn)).willReturn(
-        aResponse()
-          .withFault(Fault.MALFORMED_RESPONSE_CHUNK)
-      )
     )
   }
 }

--- a/test/controllers/NRSControllerSpec.scala
+++ b/test/controllers/NRSControllerSpec.scala
@@ -87,7 +87,7 @@ class NRSControllerSpec extends SpecBase with MockMicroserviceAuthorisedFunction
 
         "return a status of 400 (BAD_REQUEST)" in {
           mockAuthorise()(Future.successful(new ~(Some(AffinityGroup.Individual), enrolments)))
-          setupMockNrsReceiptSubmission(correctModel)(Left(Error("bad code", "bad reason")))
+          setupMockNrsReceiptSubmission(correctModel)(Left(Error("400", "bad reason")))
           status(result) shouldBe Status.BAD_REQUEST
         }
       }


### PR DESCRIPTION
NRS controller now:
- returns JSON responses instead of string body in the case of errors
- returns original NRS error code instead of BAD_REQUEST every time
- logs cause of JSON parsing error (debug level) for NRS request body to make debugging easier
- has integration tests

NRS http parser:
- uses a catch all for anything other than ACCEPTED, BAD_REQUEST, CHECKSUM_FAILED
- risk of logging potentially sensitive info from NRS removed
