### PR TITLE
BTAT-10547 Bootstrap upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,12 +48,12 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.20.0",
+  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.24.0",
   "com.typesafe.play" %% "play-json-joda" % "2.6.14"
 )
 
 def test(scope: String = "test,it"): Seq[ModuleID] = Seq(
-  "uk.gov.hmrc" %% "bootstrap-test-play-28" % "5.20.0",
+  "uk.gov.hmrc" %% "bootstrap-test-play-28" % "5.24.0",
   "org.pegdown" % "pegdown" % "1.6.0",
   "org.mockito" % "mockito-core" % "3.2.0",
   "com.github.fge" % "json-schema-validator" % "2.2.6",

--- a/it/controllers/NRSControllerISpec.scala
+++ b/it/controllers/NRSControllerISpec.scala
@@ -29,6 +29,8 @@ import scala.concurrent.Future
 
 class NRSControllerISpec extends ComponentSpecBase {
 
+  val headers = Map("Authorization" -> "localToken")
+
   "Posting to /nrs/submission/:vrn" when {
 
     "user is authorised" when {
@@ -121,7 +123,7 @@ class NRSControllerISpec extends ComponentSpecBase {
             AuthStub.stubResponse()
             NrsStub.stubSubmissionResponse(ACCEPTED, Right(NrsReceiptSuccessModel("12345")))
 
-            val response = await(Future.successful(post("/nrs/submission/999999999")(validJson)))
+            val response = await(Future.successful(post("/nrs/submission/999999999",headers)(validJson)))
 
             response.status shouldBe 202
             response.json shouldBe Json.obj("nrSubmissionId" -> "12345")
@@ -135,7 +137,7 @@ class NRSControllerISpec extends ComponentSpecBase {
             AuthStub.stubResponse()
             NrsStub.stubSubmissionResponse(SERVICE_UNAVAILABLE, Left(Error("503", "Error body")))
 
-            val response = await(Future.successful(post("/nrs/submission/999999999")(validJson)))
+            val response = await(Future.successful(post("/nrs/submission/999999999", headers)(validJson)))
 
             val expectedResponse = """"{"code":"503","reason":"Error body"}""""
 
@@ -152,7 +154,7 @@ class NRSControllerISpec extends ComponentSpecBase {
 
           AuthStub.stubResponse()
 
-          val response = await(Future.successful(post("/nrs/submission/999999999")("just a string")))
+          val response = await(Future.successful(post("/nrs/submission/999999999", headers)("just a string")))
 
           response.status shouldBe 400
           response.json shouldBe Json.obj("code" -> "400", "reason" -> "Request body cannot be parsed to JSON.")
@@ -165,7 +167,7 @@ class NRSControllerISpec extends ComponentSpecBase {
 
           AuthStub.stubResponse()
 
-          val response = await(Future.successful(post("/nrs/submission/999999999")(Json.obj("not-valid" -> "not-valid"))))
+          val response = await(Future.successful(post("/nrs/submission/999999999", headers)(Json.obj("not-valid" -> "not-valid"))))
 
           response.status shouldBe 400
           response.json shouldBe Json.obj("code" -> "400", "reason" -> "Request body does not pass validation")
@@ -179,7 +181,7 @@ class NRSControllerISpec extends ComponentSpecBase {
 
         AuthStub.stubResponse(OK, authResponse(otherEnrolment))
 
-        val response = await(Future.successful(post("/nrs/submission/999999999")(Json.obj("not-valid" -> "not-valid"))))
+        val response = await(Future.successful(post("/nrs/submission/999999999", headers)(Json.obj("not-valid" -> "not-valid"))))
 
         response.status shouldBe FORBIDDEN
       }

--- a/it/controllers/SubmitVatReturnControllerISpec.scala
+++ b/it/controllers/SubmitVatReturnControllerISpec.scala
@@ -30,7 +30,8 @@ class SubmitVatReturnControllerISpec extends ComponentSpecBase {
 
   val vrn: String = "101202303"
 
-  val headers = Map("OriginatorID" -> "VATUI")
+  val headers = Map("OriginatorID" -> "VATUI",
+  "Authorization" -> "localToken")
 
   val validJson: JsObject = Json.obj(
     "periodKey" -> "17AA",
@@ -122,7 +123,7 @@ class SubmitVatReturnControllerISpec extends ComponentSpecBase {
         "the json cannot be parsed" in {
 
           AuthStub.stubResponse()
-          val response = await(Future.successful(post("/returns/vrn/999999999")(invalidJson)))
+          val response = await(Future.successful(post("/returns/vrn/999999999", headers)(invalidJson)))
 
           response.status shouldBe INTERNAL_SERVER_ERROR
           response.json shouldBe InvalidJsonResponse.toJson
@@ -131,7 +132,7 @@ class SubmitVatReturnControllerISpec extends ComponentSpecBase {
         "request does not have an OriginatorID in header" in {
 
           AuthStub.stubResponse()
-          val response = await(Future.successful(post("/returns/vrn/999999999")(validJson)))
+          val response = await(Future.successful(post("/returns/vrn/999999999", Map("Authorization" -> "localToken"))(validJson)))
 
           response.status shouldBe BAD_REQUEST
           response.json shouldBe Json.obj("code" -> "400", "reason" -> "No OriginatorID found in header")
@@ -140,7 +141,8 @@ class SubmitVatReturnControllerISpec extends ComponentSpecBase {
         "OriginatorID in header is invalid" in {
 
           AuthStub.stubResponse()
-          val response = await(Future.successful(post("/returns/vrn/999999999", Map("OriginatorID" -> "Another channel"))(validJson)))
+          val response = await(Future.successful(
+            post("/returns/vrn/999999999", Map("OriginatorID" -> "Another channel","Authorization" -> "localToken"))(validJson)))
 
           response.status shouldBe BAD_REQUEST
           response.json shouldBe Json.obj("code" -> "400", "reason" -> "Invalid OriginatorID header value")
@@ -154,7 +156,7 @@ class SubmitVatReturnControllerISpec extends ComponentSpecBase {
 
         AuthStub.stubResponse()
 
-        val response = await(Future.successful(post("/returns/vrn/123123123")(validJson)))
+        val response = await(Future.successful(post("/returns/vrn/123123123", headers)(validJson)))
 
         response.status shouldBe FORBIDDEN
       }
@@ -166,7 +168,7 @@ class SubmitVatReturnControllerISpec extends ComponentSpecBase {
 
         AuthStub.stubResponse(OK, authResponse(otherEnrolment))
 
-        val response = await(Future.successful(post("/returns/vrn/999999999")(validJson)))
+        val response = await(Future.successful(post("/returns/vrn/999999999", headers)(validJson)))
 
         response.status shouldBe FORBIDDEN
       }

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -80,6 +80,6 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
     await(buildClient(path, headers).post(body))
 
   def get(uri: String): WSResponse = {
-    await(buildClient(uri).get())
+    await(buildClient(uri).withHttpHeaders("Authorization" -> "localToken").get())
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 


### PR DESCRIPTION
Because of the way the buildClient function was being mocked to accept header parameters I had to update a number of IT tests to pass the Authorisation header explicitly. 