### PR TITLE
BTAT-11515 Added HttpException recovery to connectors

### DIFF
--- a/test/connectors/NrsConnectorSpec.scala
+++ b/test/connectors/NrsConnectorSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.SpecBase
+import connectors.httpParsers.NrsResponseParsers.SubmissionResult
+import mocks.MockHttp
+import models.nrs.NrsReceiptRequestModel
+import models.Error
+import play.api.http.Status.BAD_GATEWAY
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.RequestTimeoutException
+import utils.NrsTestData.FullRequestTestData.correctModel
+
+import scala.concurrent.Future
+
+class NrsConnectorSpec extends SpecBase with MockHttp {
+
+  val connector = new NrsConnector(mockHttpGet, mockAppConfig)
+  val vrn = "123456789"
+
+  "NrsConnector" should {
+
+    "return an Error model when a HTTP exception is received" in {
+      val exception = new RequestTimeoutException("Request timed out!!!")
+      setupMockHttpPost[NrsReceiptRequestModel, SubmissionResult](connector.urlToUse(vrn))(Future.failed(exception))
+      val result: Future[SubmissionResult] = connector.nrsReceiptSubmission(correctModel)
+      await(result) shouldBe Left(Error(BAD_GATEWAY.toString, exception.message))
+    }
+  }
+}

--- a/test/connectors/VatReturnsConnectorSpec.scala
+++ b/test/connectors/VatReturnsConnectorSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.SpecBase
+import mocks.MockHttp
+import models.{Error, ErrorResponse, VatReturnDetail, VatReturnFilters}
+import play.api.http.Status.BAD_GATEWAY
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.RequestTimeoutException
+
+import scala.concurrent.Future
+
+class VatReturnsConnectorSpec extends SpecBase with MockHttp {
+
+  val connector = new VatReturnsConnector(mockHttpGet, mockAppConfig)
+  val vrn = "123456789"
+
+  "VatReturnsConnector" should {
+
+    "return an Error model when a HTTP exception is received" in {
+      val exception = new RequestTimeoutException("Request timed out!!!")
+      setupMockHttpGet[VatReturnDetail](connector.setupDesVatReturnsUrl(vrn))(Future.failed(exception))
+      val result = connector.getVatReturns(vrn, VatReturnFilters("#001"))
+      await(result) shouldBe Left(ErrorResponse(BAD_GATEWAY, Error("BAD_GATEWAY", exception.message)))
+    }
+  }
+}

--- a/test/mocks/MockHttp.scala
+++ b/test/mocks/MockHttp.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar
-import uk.gov.hmrc.http.{HttpClient, HttpResponse}
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.Future
 
@@ -37,14 +37,15 @@ trait MockHttp extends AnyWordSpecLike with Matchers with OptionValues with Mock
     reset(mockHttpGet)
   }
 
-  def setupMockHttpGet[A](url: String)(response: A): OngoingStubbing[Future[A]] =
+  def setupMockHttpGet[A](url: String)(response: Future[A]): OngoingStubbing[Future[A]] =
     when(mockHttpGet.GET[A](ArgumentMatchers.eq(url), any(), any())(any(), any(), any()))
-      .thenReturn(Future.successful(response))
+      .thenReturn(response)
 
-  def setupMockHttpGet[A](url: String, queryParams: Seq[(String, String)])(response: A): OngoingStubbing[Future[A]] =
+  def setupMockHttpGet[A](url: String, queryParams: Seq[(String, String)])(response: Future[A]): OngoingStubbing[Future[A]] =
     when(mockHttpGet.GET[A](ArgumentMatchers.eq(url), ArgumentMatchers.eq(queryParams), any())(any(),
-      any(), any())).thenReturn(Future.successful(response))
+      any(), any())).thenReturn(response)
 
-  def setupMockFailedHttpGet[A](url: String)(response: HttpResponse): OngoingStubbing[Future[A]] =
-    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url))(any(), any(), any())).thenReturn(Future.failed(new Exception))
+  def setupMockHttpPost[A, B](url: String)(response: Future[B]): OngoingStubbing[Future[B]] =
+    when(mockHttpGet.POST[A, B](ArgumentMatchers.eq(url), any(), any())(any(), any(), any(), any()))
+      .thenReturn(response)
 }


### PR DESCRIPTION
Please also merge this: https://github.com/hmrc/app-config-production/pull/17949

The NrsConnector needed to have "502" as a String as the controller attempts to convert this to an Int later on. Seems like a not ideal way of doing things but I didn't think a refactor was appropriate